### PR TITLE
Pkg 4699 12.4 initial

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 build:
   number: 1
   binary_relocation: false
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - patchelf <0.18.0                      # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -83,8 +83,8 @@ outputs:
       - Library\include                                   # [win]
       - Library\lib\nvjpeg.lib                            # [win]
     requirements:
-      build:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      #build:
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -119,8 +119,8 @@ outputs:
     files:
       - targets/{{ target_name }}/lib/libnvjpeg_static.a  # [linux]
     requirements:
-      build:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      #build:
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
         - cuda-version {{ cuda_version }}
       run:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4699](https://anaconda.atlassian.net/browse/PKG-4699)

### Explanation of changes:

- Part of CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. There isn't a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Changes made to adjust feedstocks for differences between conda-forge and defaults. Please see commit messages for description of changes.


[PKG-4599]: https://anaconda.atlassian.net/browse/PKG-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-4699]: https://anaconda.atlassian.net/browse/PKG-4699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ