### PR TITLE
libnvjpeg v13.0.3.75

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -18,8 +16,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-jpeg:
-- '9'
 target_platform:
 - linux-64
 xz:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -20,8 +18,6 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-jpeg:
-- '9'
 target_platform:
 - linux-aarch64
 xz:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,7 +8,5 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-jpeg:
-- '9'
 target_platform:
 - win-64

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -202,7 +202,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libnvjpeg-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libnvjpeg" %}
-{% set version = "13.0.1.86" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.0.2.28" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: ebef16a52d31d2de0e888f0fd9c788bfe99be988ebad4927754e5ccdfdae6360  # [linux64]
-  sha256: 6132e76ec6064881592b38ef5b2a135237005d8533660ee8f525b120a178d1f4  # [aarch64]
-  sha256: b8d64f9fb90632e33685529e2b8baee245ca3dcaecab4b8998815ae0f44c5171  # [win]
+  sha256: 4f1d447822b34d57dbe3f9b5e805f1066e08a9d3dea8b3a4c76c3e4b5d39b84c  # [linux64]
+  sha256: 9da4922171fb707376e86862c9edbe8a694692f91709a6903571b7564d73011b  # [aarch64]
+  sha256: 3cf694b6d8858bd7f7de436c31ef227834880ae376eff5a8f79d8a42ef46b875  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libnvjpeg" %}
-{% set version = "13.0.2.28" %}
+{% set version = "13.0.3.75" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 4f1d447822b34d57dbe3f9b5e805f1066e08a9d3dea8b3a4c76c3e4b5d39b84c  # [linux64]
-  sha256: 9da4922171fb707376e86862c9edbe8a694692f91709a6903571b7564d73011b  # [aarch64]
-  sha256: 3cf694b6d8858bd7f7de436c31ef227834880ae376eff5a8f79d8a42ef46b875  # [win]
+  sha256: 3cab9b53be22df1f107f8c0d5fc26c76b7d3dd74abee1b2390be81a3a9454065  # [linux64]
+  sha256: 464f3b0426b64a1f6fbe381f91f1dd9b65527c07fc3f388f4ca584534ab5e782  # [aarch64]
+  sha256: b1681853ec61f9f34532c7de312678e61c3726fb7cc60fe40e2a72e838465e92  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
libnvjpeg 13.0.3.75

**Destination channel:** defaults

### Links

- [PKG-12028](https://anaconda.atlassian.net/browse/PKG-12028) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12028]: https://anaconda.atlassian.net/browse/PKG-12028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ