### PR TITLE
libnvjpeg v12.4.0.76

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+# - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,10 @@
 {% set version = "12.4.0.76" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set platform = "linux-aarch64" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64 and arm_variant_type=="sbsa"]
 {% set target_name = "aarch64-linux" %}  # [aarch64 and arm_variant_type=="tegra"]
 {% set target_name = "x64" %}  # [win]
@@ -26,17 +24,25 @@ source:
   sha256: b253241fc88bf30947b8ee068101aca8930960f113d8ee4a9583de021a79ffa1  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
     - cf-nvidia-tools 1.*  # [linux]
-    - patchelf <0.18.0                      # [linux]
+    - patchelf <0.18.0     # [linux]
 
 outputs:
   - name: libnvjpeg
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'           # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libnvjpeg*.so*'         # [linux and aarch64]
     files:
       - lib/libnvjpeg.so.*            # [linux]
       - targets/{{ target_name }}/lib/libnvjpeg.so.*  # [linux]
@@ -69,10 +75,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      licence_family: Other
       summary: nvJPEG native runtime libraries
       description: |
         nvJPEG native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+      dev_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
 
   - name: libnvjpeg-dev
     build:
@@ -112,10 +120,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: nvJPEG native runtime libraries
       description: |
         nvJPEG native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+      dev_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
 
   - name: libnvjpeg-static
     build:
@@ -138,20 +148,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: nvJPEG native runtime libraries
       description: |
         nvJPEG native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+      dev_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
 
 about:
   home: https://developer.nvidia.com/nvjpeg
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: nvJPEG native runtime libraries
   description: |
     nvJPEG native runtime libraries
   doc_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
+  dev_url: https://docs.nvidia.com/cuda/nvjpeg/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libnvjpeg 12.4.0.76

**Destination channel:** defaults

### Links

- [PKG-12797](https://anaconda.atlassian.net/browse/PKG-12797) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's `12.x` branch.
- Added `abs.yaml` for possible use of staging channels in future builds
- Removed Tegra builds from `cbc.yaml`. We may enable them in the future.
- Kept static library packages as they are dependencies for `cuda-libraries-static` package.

[PKG-12797]: https://anaconda.atlassian.net/browse/PKG-12797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ